### PR TITLE
Temp paths combined using java.io.File

### DIFF
--- a/src/test/java/com/deviantart/kafka_connect_s3/BlockGZIPFileWriterTest.java
+++ b/src/test/java/com/deviantart/kafka_connect_s3/BlockGZIPFileWriterTest.java
@@ -26,7 +26,7 @@ public class BlockGZIPFileWriterTest extends TestCase {
     super(testName);
 
     String tempDir = System.getProperty("java.io.tmpdir");
-    this.tmpDir = tempDir.concat(tmpDirPrefix);
+    this.tmpDir = new File(tempDir, tmpDirPrefix).toString();
 
     System.out.println("Temp dir for writer test is: " + tmpDir);
   }

--- a/src/test/java/com/deviantart/kafka_connect_s3/S3WriterTest.java
+++ b/src/test/java/com/deviantart/kafka_connect_s3/S3WriterTest.java
@@ -46,7 +46,7 @@ public class S3WriterTest extends TestCase {
     super(testName);
 
     String tempDir = System.getProperty("java.io.tmpdir");
-    this.tmpDir = tempDir.concat(tmpDirPrefix);
+    this.tmpDir = new File(tempDir, tmpDirPrefix).toString();
 
     System.out.println("Temp dir for writer test is: " + tmpDir);
   }


### PR DESCRIPTION
 This handles a java.io.tmpdir value that may or may not end with a '/'. Before, tests would fail if java.io.tmpdir did not end with a '/' char.  This is the output from the tests:

> Running com.deviantart.kafka_connect_s3.BlockGZIPFileWriterTest
> Temp dir for writer test is: /tmpBlockGZIPFileWriterTest
> Temp dir for writer test is: /tmpBlockGZIPFileWriterTest
> Temp dir for writer test is: /tmpBlockGZIPFileWriterTest
> Temp dir for writer test is: /tmpBlockGZIPFileWriterTest
> Tests run: 4, Failures: 0, Errors: 4, Skipped: 0, Time elapsed: 1.606 sec <<< FAILURE!
> Running com.deviantart.kafka_connect_s3.S3WriterTest
> Temp dir for writer test is: /tmpS3WriterTest
> Temp dir for writer test is: /tmpS3WriterTest
> Temp dir for writer test is: /tmpS3WriterTest
> MADE MOCK FOR pfx/last_chunk_index.bar-00000.txt WITH BODY: pfx/2016-04-19/bar-00000-000000010042.index.json
> MADE MOCK FOR pfx/2016-04-19/bar-00000-000000010042.index.json WITH BODY: {"chunks":[{"first_record_offset":10042,"num_records":1\
> 000,"byte_offset":0,"byte_length":10000},{"first_record_offset":11042,"num_records":989,"byte_offset":10000,"byte_length":9890},{\
> "first_record_offset":12031,"num_records":34,"byte_offset":19890,"byte_length":340}]}
> Tests run: 3, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 17.337 sec <<< FAILURE!
