### PR TITLE
safer .gitignore patterns from gitignore.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
-target
 local-*
+# Created by https://www.gitignore.io/api/maven
+
+### Maven ###
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
 dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties


### PR DESCRIPTION
Use patterns from community-maintained gitignore.io database, rather than hand-rolled patterns, to reduce false negatives and false positives when working with git and various junk files.
