### PR TITLE
Add missing local.buffer.dir

### DIFF
--- a/example-connect-s3-sink.properties
+++ b/example-connect-s3-sink.properties
@@ -4,3 +4,4 @@ tasks.max=1
 topics=test
 s3.bucket=connect-test
 s3.prefix=/connect-test
+local.buffer.dir=/tmp/kafka-connect-s3.buffer


### PR DESCRIPTION
This is required to start, according to the errors that are emitted if it's absent.