### PR TITLE
Fix example S3 prefix

### DIFF
--- a/example-connect-s3-sink.properties
+++ b/example-connect-s3-sink.properties
@@ -3,4 +3,4 @@ connector.class=com.deviantart.kafka_connect_s3.S3SinkConnector
 tasks.max=1
 topics=test
 s3.bucket=connect-test
-s3.prefix=/connect-test
+s3.prefix=connect-test


### PR DESCRIPTION
The previous example caused strange behavior in S3, where the file path names are actually `//connect-test`, not `/connect-test` as intended. This causes some S3 clients to break. The AWS console shows these, but with strange behavior.

![S3 Management Console showing the root of the bucket](https://cloud.githubusercontent.com/assets/1005280/22408293/e2dcdeb2-e644-11e6-9873-394b3f8fb684.jpg)

After double-clicking the unnamed folder:
![S3 Management Console showing the parent of the connect-test "folder"](https://cloud.githubusercontent.com/assets/1005280/22408324/35f69250-e645-11e6-8347-a327b96b1c98.jpg)

And after opening the `connect-test` folder:
![S3 Management Console showing the connect-test "folder"](https://cloud.githubusercontent.com/assets/1005280/22408309/f5e9c33a-e644-11e6-847c-00d8031cc3c8.jpg)
