### PR TITLE
Improve test/Docker documentation

### DIFF
--- a/system_test/.gitignore
+++ b/system_test/.gitignore
@@ -1,1 +1,2 @@
 standalone-kafka
+data

--- a/system_test/README.md
+++ b/system_test/README.md
@@ -30,23 +30,25 @@ $ [sudo] pip install boto
 Since setup is somewhat expensive and complicated to automate in a highly portable fashion, we
 make setup a somewhat manual step to perform before running tests.
 
-#### 1. Ensure standalone docker image is running
+### Start standalone-kafka Docker image
 
 Kafka must be accessible on `localhost:9092`.
 
 Run it with:
 
 ```sh
-$ docker run -d --net=host -e HOSTNAME=localhost deviantart/standalone-kafka
+$ docker run -d -p 2181:2181 -p 9092:9092 --name kafka deviantart/standalone-kafka
 ```
 
 The `name` param means you can use `$ docker kill kafka` when you're done.
 
-On linux (where docker daemon is running directly on host kernel) you should be done.
+### Map ports (old versions of Docker)
 
-For OS X or other setup where docker is running in a VM, you now need to forward localhost ports to the VM.
+On newer versions of Docker (where Docker daemon is running directly on host kernel) you should be done.
 
-Assuming you used docker machine you can do this with:
+Older versions of Docker, where docker is running inside of a virtual machine, you now need to forward localhost ports to the virtual machine.
+
+Assuming you're using [docker-machine](https://docs.docker.com/machine/overview/) to manage the virtual machine, you can map the ports with:
 
 ```sh
 $ docker-machine ssh default -f -N -L 9092:localhost:9092 -L 2181:localhost:2181

--- a/system_test/README.md
+++ b/system_test/README.md
@@ -5,7 +5,7 @@
 These steps should be required just once.
 
  - Install [Docker](https://docker.io)
- - Install [standalone kafka docker tool](https://github.com/DeviantArt/standalone-kafka), _in this directory_. It's already in `.gitignore`. If you already have it elsewhere or wish to share the installation, create a symlink so that we can find the helper scripts in `./system-test/standalone-kafka/kafka/bin/` relative to this repo's root.
+ - Install [standalone kafka docker tool](https://github.com/DeviantArt/standalone-kafka), _in the `system_test` directory_. It's already in `.gitignore`. If you already have it elsewhere or wish to share the installation, create a symlink so that we can find the helper scripts in `./system-test/standalone-kafka/kafka/bin/` relative to this repo's root.
   - Note that we rely on `auto.create.topics.enable = true` in the kafka broker config
 ```sh
 $ git clone https://github.com/DeviantArt/standalone-kafka.git

--- a/system_test/README.md
+++ b/system_test/README.md
@@ -7,21 +7,21 @@ These steps should be required just once.
  - Install [Docker](https://docker.io)
  - Install [standalone kafka docker tool](https://github.com/DeviantArt/standalone-kafka), _in this directory_. It's already in `.gitignore`. If you already have it elsewhere or wish to share the installation, create a symlink so that we can find the helper scripts in `./system-test/standalone-kafka/kafka/bin/` relative to this repo's root.
   - Note that we rely on `auto.create.topics.enable = true` in the kafka broker config
-```
+```sh
 $ git clone https://github.com/DeviantArt/standalone-kafka.git
 $ cd standalone-kafka
 $ docker build -t deviantart/standalone-kafka .
 ```
  - Install [FakeS3](https://github.com/jubos/fake-s3) (assumes you have ruby/gem installed)
-```
+```sh
 $ [sudo] gem install fakes3
 ```
  - Install [kafka-python](https://github.com/dpkp/kafka-python)
-```
+```sh
 $ [sudo] pip install kafka-python
 ```
  - Install [boto](https://github.com/boto/boto)
-```
+```sh
 $ [sudo] pip install boto
 ```
 
@@ -36,7 +36,7 @@ Kafka must be accessible on `localhost:9092`.
 
 Run it with:
 
-```
+```sh
 $ docker run -d --net=host -e HOSTNAME=localhost deviantart/standalone-kafka
 ```
 
@@ -48,7 +48,7 @@ For OS X or other setup where docker is running in a VM, you now need to forward
 
 Assuming you used docker machine you can do this with:
 
-```
+```sh
 $ docker-machine ssh default -f -N -L 9092:localhost:9092 -L 2181:localhost:2181
 ```
 
@@ -61,6 +61,6 @@ The same should work with regular ssh for a non-docker machine VM.
 
 From the repo root dir, run:
 
-```
+```sh
 $ python system_test/run.py
 ```


### PR DESCRIPTION
- Docker on Mac no longer requires a VM or docker-machine, so make that slightly more clear.
- Updated the `docker run` command to match the current version of [standalone-kafka's readme](https://github.com/DeviantArt/standalone-kafka/blob/master/README.md). This updated command starts the container with mapped ports.
- Be more explicit about the directory that standalone-kafka should be cloned into.
- Add `system_test/data` directory to `.gitignore`, since it is created during test runs.
- Add syntax highlighting to the shell commands in the doc.
