### PR TITLE
Kafka 0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kafka Connect S3 Sink
 
-This is a [kafka-connect](http://kafka.apache.org/documentation.html#connect) sink for Amazon S3, but without any dependency on HDFS/hadoop libs or data formats.
+This is a [kafka-connect](http://kafka.apache.org/documentation.html#connect) sink for Amazon S3, without any dependency on HDFS/Hadoop libraries or data formats.
 
 ## Status
 
@@ -10,7 +10,7 @@ That said, we've put some effort into a reasonably thorough test suite and will 
 
 If you use it, you will likely find issues or ways it can be improved. Please feel free to create pull requests/issues and we will do our best to merge anything that helps overall (especially if it has passing tests ;)).
 
-This was built against Kafka 0.9.0.1.
+This was built against Kafka 0.10.1.1.
 
 ## Block-GZIP Output Format
 
@@ -108,6 +108,7 @@ In addition to the [standard kafka-connect config options](http://kafka.apache.o
 | Config Key | Default | Notes |
 | ---------- | ------- | ----- |
 | s3.bucket | **REQUIRED** | The name of the bucket to write too. |
+| local.buffer.dir | **REQUIRED** | Directory to store buffered data in. Must exist. |
 | s3.prefix | `""` | Prefix added to all object keys stored in bucket to "namespace" them. |
 | s3.endpoint | AWS defaults per region | Mostly useful for testing. |
 | s3.path_style | `false` | Force path-style access to bucket rather than subdomain. Mostly useful for tests. |

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   </build>
 
   <properties>
-    <kafka.version>0.9.0.1</kafka.version>
+    <kafka.version>0.10.1.1</kafka.version>
     <s3.version>1.10.37</s3.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/src/main/java/com/deviantart/kafka_connect_s3/S3SinkConnector.java
+++ b/src/main/java/com/deviantart/kafka_connect_s3/S3SinkConnector.java
@@ -1,20 +1,51 @@
 package com.deviantart.kafka_connect_s3;
 
-import org.apache.kafka.connect.connector.Connector;
+import org.apache.kafka.connect.sink.SinkConnector;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Range;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigValue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 /**
  * S3SinkConnector is a Kafka Connect Connector implementation that exports data from Kafka to S3.
  */
-public class S3SinkConnector extends Connector {
+public class S3SinkConnector extends SinkConnector {
 
-  private Map<String, String> configProperties;
+  public static final String MAX_BLOCK_SIZE_CONFIG = "compressed_block_size";
+
+  public static final Long DEFAULT_MAX_BLOCK_SIZE = 67108864L;
+
+  public static final String S3_BUCKET_CONFIG = "s3.bucket";
+
+  public static final String S3_PREFIX_CONFIG = "s3.prefix";
+
+  public static final String OVERRIDE_S3_ENDPOINT_CONFIG = "s3.endpoint";
+
+  public static final String S3_PATHSTYLE_CONFIG = "s3.path_style";
+
+  public static final String BUFFER_DIRECTORY_PATH_CONFIG = "local.buffer.dir";
+
+  public static final ConfigDef CONFIG_DEF = new ConfigDef()
+    .define(MAX_BLOCK_SIZE_CONFIG, Type.LONG, DEFAULT_MAX_BLOCK_SIZE, Range.atLeast(0), Importance.LOW, "Maximum size of data chunks in bytes (before compression)")
+    .define(S3_BUCKET_CONFIG, Type.STRING, Importance.HIGH, "Name of the S3 bucket")
+    .define(S3_PREFIX_CONFIG, Type.STRING, "", Importance.HIGH, "Path prefix of files to be written to S3")
+    .define(OVERRIDE_S3_ENDPOINT_CONFIG, Type.STRING, "", Importance.LOW, "Override the S3 URL endpoint")
+    .define(S3_PATHSTYLE_CONFIG, Type.BOOLEAN, false, Importance.LOW, "Override the standard S3 URL style by placing the bucket name in the path instead of hostname")
+    .define(BUFFER_DIRECTORY_PATH_CONFIG, Type.STRING, Importance.HIGH, "Path to directory to store data temporarily before uploading to S3")
+    ;
+
+  private Map<String, Object> configProperties;
 
   @Override
   public String version() {
@@ -23,7 +54,7 @@ public class S3SinkConnector extends Connector {
 
   @Override
   public void start(Map<String, String> props) throws ConnectException {
-    configProperties = props;
+    readConfig(props);
   }
 
   @Override
@@ -33,17 +64,38 @@ public class S3SinkConnector extends Connector {
 
   @Override
   public List<Map<String, String>> taskConfigs(int maxTasks) {
-    List<Map<String, String>> taskConfigs = new ArrayList<>();
-    Map<String, String> taskProps = new HashMap<>();
-    taskProps.putAll(configProperties);
+    ArrayList<Map<String, String>> configs = new ArrayList<>();
     for (int i = 0; i < maxTasks; i++) {
-      taskConfigs.add(taskProps);
+      Map<String, String> props = new HashMap<>();
+      System.out.println(configProperties);
+      props.put(MAX_BLOCK_SIZE_CONFIG, configProperties.get(MAX_BLOCK_SIZE_CONFIG).toString());
+      props.put(S3_BUCKET_CONFIG, configProperties.get(S3_BUCKET_CONFIG).toString());
+      props.put(S3_PREFIX_CONFIG, configProperties.get(S3_PREFIX_CONFIG).toString());
+      props.put(OVERRIDE_S3_ENDPOINT_CONFIG, configProperties.get(OVERRIDE_S3_ENDPOINT_CONFIG).toString());
+      props.put(S3_PATHSTYLE_CONFIG, configProperties.get(S3_PATHSTYLE_CONFIG).toString());
+      props.put(BUFFER_DIRECTORY_PATH_CONFIG, configProperties.get(BUFFER_DIRECTORY_PATH_CONFIG).toString());
+      configs.add(props);
     }
-    return taskConfigs;
+    return configs;
+  }
+
+  private void readConfig(Map<String, String> props) {
+    // Validates the configuration and returns the valid config or throws an exception.
+    configProperties = CONFIG_DEF.parse(props);
+
+    String bufferDirectoryPath = configProperties.get(BUFFER_DIRECTORY_PATH_CONFIG).toString();
+    if (!Files.isDirectory(Paths.get(bufferDirectoryPath))) {
+      throw new ConnectException(String.format("%s not a directory or not valid: %s", BUFFER_DIRECTORY_PATH_CONFIG, bufferDirectoryPath));
+    }
   }
 
   @Override
   public void stop() throws ConnectException {
 
+  }
+
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
   }
 }

--- a/src/main/java/com/deviantart/kafka_connect_s3/S3SinkConnector.java
+++ b/src/main/java/com/deviantart/kafka_connect_s3/S3SinkConnector.java
@@ -67,7 +67,6 @@ public class S3SinkConnector extends SinkConnector {
     ArrayList<Map<String, String>> configs = new ArrayList<>();
     for (int i = 0; i < maxTasks; i++) {
       Map<String, String> props = new HashMap<>();
-      System.out.println(configProperties);
       props.put(MAX_BLOCK_SIZE_CONFIG, configProperties.get(MAX_BLOCK_SIZE_CONFIG).toString());
       props.put(S3_BUCKET_CONFIG, configProperties.get(S3_BUCKET_CONFIG).toString());
       props.put(S3_PREFIX_CONFIG, configProperties.get(S3_PREFIX_CONFIG).toString());


### PR DESCRIPTION
Upgrade Kafka to 0.10.1.1. To support this, the following changes were made:

- Instead of subclassing `org.apache.kafka.connect.connector.Connector, subclass `org.apache.kafka.connect.sink.SinkConnector`.
- Parse configuration options using `org.apache.kafka.common.config.ConfigDef` and add a `config` method that returns this structure.
- The `ConfigDef` option defines any default values and documents the options.

We no longer validate configuration directly, we instead rely on `ConfigDef.parse`, which will throw an exception if items are missing or invalid.

I also added validation of the `local.buffer.dir` to ensure that it exists and is a directory. Previously, if it turned out to be invalid, it would throw an exception the first time it tried to write a file in that directory.